### PR TITLE
refactor: split BaseInput, removed classes from svg icons.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,5 +5,3 @@ import MainView from '@/views/MainView.vue';
 <template>
   <MainView />
 </template>
-
-<style scoped></style>

--- a/src/components/fieldsets/TimerSettingsModalFieldsetTimer.vue
+++ b/src/components/fieldsets/TimerSettingsModalFieldsetTimer.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import BaseInput from '@/components/inputs/BaseInput.vue';
-import RadioInput from '../inputs/RadioInput.vue';
+import RadioInput from '@/components/inputs/RadioInput.vue';
 
 const timerFormat = defineModel<string>('timerFormat');
 </script>

--- a/src/components/fieldsets/TimerSettingsModalFieldsetTimer.vue
+++ b/src/components/fieldsets/TimerSettingsModalFieldsetTimer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import BaseInput from '@/components/inputs/BaseInput.vue';
+import RadioInput from '../inputs/RadioInput.vue';
 
 const timerFormat = defineModel<string>('timerFormat');
 </script>
@@ -8,8 +9,8 @@ const timerFormat = defineModel<string>('timerFormat');
   <fieldset class="fieldset-timer">
     <legend>Choose a timer format</legend>
     <div>
-      <BaseInput v-model="timerFormat" type="radio" value="minutes" label="Minutes" />
-      <BaseInput v-model="timerFormat" type="radio" value="seconds" label="Seconds" />
+      <RadioInput v-model="timerFormat" value="minutes" label="Minutes" />
+      <RadioInput v-model="timerFormat" value="seconds" label="Seconds" />
     </div>
   </fieldset>
 </template>

--- a/src/components/icons/IconCancelButton.vue
+++ b/src/components/icons/IconCancelButton.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="cancelButton" fill="#000000" height="25px" width="25px" version="1.1"
+    fill="#000000" height="25px" width="25px" version="1.1"
     xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
     viewBox="0 0 512 512" xml:space="preserve"
   >
@@ -17,17 +17,3 @@
     </g>
   </svg>
 </template>
-
-<style scoped>
-.cancelButton {
-  position: absolute;
-  top: -40px;
-  right: 105%;
-}
-
-svg:hover {
-  cursor: pointer;
-  transform: scale(1.1);
-  transition-duration: 100ms;
-}
-</style>

--- a/src/components/icons/IconForwardButton.vue
+++ b/src/components/icons/IconForwardButton.vue
@@ -1,6 +1,5 @@
 <template>
   <svg
-    class="forwardButton"
     version="1.1" xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512.008 512.008"
     style="enable-background:new 0 0 512.008 512.008;" xml:space="preserve"
@@ -20,20 +19,3 @@
     </g>
   </svg>
 </template>
-
-<style scoped>
-.forwardButton {
-  position: absolute;
-  right: -20%;
-}
-svg {
-  height: 100%;
-  height: 30px;
-}
-
-svg:hover {
-  cursor: pointer;
-  transform: scale(1.1);
-  transition-duration: 100ms;
-}
-</style>

--- a/src/components/icons/IconSettings.vue
+++ b/src/components/icons/IconSettings.vue
@@ -33,16 +33,3 @@
     </g>
   </svg>
 </template>
-
-<style scoped>
-svg {
-  height: 100%;
-  height: 30px;
-}
-
-svg:hover {
-  cursor: pointer;
-  transform: scale(1.1);
-  transition-duration: 100ms;
-}
-</style>

--- a/src/components/inputs/BaseInput.vue
+++ b/src/components/inputs/BaseInput.vue
@@ -35,8 +35,8 @@ const inputId = useId();
 
 <style scoped>
 .base-input {
-  padding: 5px;
-  margin: 5px;
+  padding: 4px;
+  margin: 4px;
   background-color: rgba(128, 92, 92, 0.7);
 }
 </style>

--- a/src/components/inputs/BaseInput.vue
+++ b/src/components/inputs/BaseInput.vue
@@ -24,6 +24,7 @@ const inputId = useId();
   <input
     :id="inputId"
     v-model="modelValue"
+    class="base-input"
     :placeholder="placeholder"
     :type="type"
     :min="min"
@@ -33,7 +34,7 @@ const inputId = useId();
 </template>
 
 <style scoped>
-input {
+.base-input {
   padding: 5px;
   margin: 5px;
   background-color: rgba(128, 92, 92, 0.7);

--- a/src/components/inputs/RadioInput.vue
+++ b/src/components/inputs/RadioInput.vue
@@ -14,11 +14,11 @@ const inputId = useId();
 
 <template>
   <label :for="inputId">{{ label }}</label>
-  <input :id="inputId" v-model="modelValue" type="radio" :value="value ">
+  <input :id="inputId" v-model="modelValue" class="radio-input" type="radio" :value="value ">
 </template>
 
 <style scoped>
-input {
+.radio-input {
   padding: 4px;
   margin: 4px;
   background-color: rgba(128, 92, 92, 0.7);

--- a/src/components/inputs/RadioInput.vue
+++ b/src/components/inputs/RadioInput.vue
@@ -3,33 +3,18 @@ import { useId } from 'vue';
 
 interface Props {
   label: string
-  type: string
-  placeholder?: string
-  min?: string
-  max?: string
-  step?: string
   value?: string
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 const modelValue = defineModel();
 
 const inputId = useId();
 </script>
 
 <template>
-  <label :for="inputId">
-    {{ label }}
-  </label>
-  <input
-    :id="inputId"
-    v-model="modelValue"
-    :placeholder="placeholder"
-    :type="type"
-    :min="min"
-    :max="max"
-    :step="step"
-  >
+  <label :for="inputId">{{ props.label }}</label>
+  <input :id="inputId" v-model="modelValue" type="radio" :value="props.value ">
 </template>
 
 <style scoped>

--- a/src/components/inputs/RadioInput.vue
+++ b/src/components/inputs/RadioInput.vue
@@ -6,21 +6,21 @@ interface Props {
   value?: string
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 const modelValue = defineModel();
 
 const inputId = useId();
 </script>
 
 <template>
-  <label :for="inputId">{{ props.label }}</label>
-  <input :id="inputId" v-model="modelValue" type="radio" :value="props.value ">
+  <label :for="inputId">{{ label }}</label>
+  <input :id="inputId" v-model="modelValue" type="radio" :value="value ">
 </template>
 
 <style scoped>
 input {
-  padding: 5px;
-  margin: 5px;
+  padding: 4px;
+  margin: 4px;
   background-color: rgba(128, 92, 92, 0.7);
 }
 </style>

--- a/src/components/timer/TimerMain.vue
+++ b/src/components/timer/TimerMain.vue
@@ -157,6 +157,10 @@ onUnmounted(() => {
   margin-bottom: 1.5rem;
 }
 
+.timer__settings {
+  will-change: transform;
+}
+
 .timer__settings > svg {
   height: 32px;
 }
@@ -177,6 +181,7 @@ onUnmounted(() => {
 .timer__forward-button {
   position: absolute;
   right: -20%;
+  will-change: transform;
 }
 
 .timer__forward-button > svg {

--- a/src/components/timer/TimerMain.vue
+++ b/src/components/timer/TimerMain.vue
@@ -86,7 +86,7 @@ onUnmounted(() => {
       :timer-settings="timerSettings"
       :timer-type="timerState.timerType"
     />
-    <div ref="settingsIconRef" @click="showModal = !showModal">
+    <div ref="settingsIconRef" class="timer__settings" @click="showModal = !showModal">
       <IconSettings />
     </div>
     <div class="timer__title">
@@ -109,9 +109,11 @@ onUnmounted(() => {
       <TimerButton v-else-if="isTimerStarted" @click="pauseTimer">
         Pause
       </TimerButton>
-      <Transition>
-        <IconForwardButton v-if="isTimerStarted" @click="changeTimer" />
-      </Transition>
+      <div class="timer__forward-button">
+        <Transition>
+          <IconForwardButton v-if="isTimerStarted" @click="changeTimer" />
+        </Transition>
+      </div>
     </div>
   </div>
   <TimerSettingsModal
@@ -128,8 +130,8 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   font-family: Arial, sans-serif;
-  border-radius: 10px;
-  padding: 6px;
+  border-radius: 8px;
+  padding: 8px;
   color: #fff;
 }
 
@@ -155,11 +157,37 @@ onUnmounted(() => {
   margin-bottom: 1.5rem;
 }
 
+.timer__settings > svg {
+  height: 32px;
+}
+
+.timer__settings:hover {
+  cursor: pointer;
+  transform: scale(1.04);
+  transition-duration: 100ms;
+}
+
 .timer__controls {
   display: flex;
   position: relative;
   align-items: center;
   gap: 0.5rem;
+}
+
+.timer__forward-button {
+  position: absolute;
+  right: -20%;
+}
+
+.timer__forward-button > svg {
+  height: 100%;
+  height: 32px;
+}
+
+.timer__forward-button > svg:hover {
+  cursor: pointer;
+  transform: scale(1.1);
+  transition-duration: 100ms;
 }
 
 .v-enter-active,

--- a/src/components/timer/TimerRoundsCounter.vue
+++ b/src/components/timer/TimerRoundsCounter.vue
@@ -58,6 +58,7 @@ onUnmounted(() => clearInterval(timeoutId));
   height: 0px;
   top: -40px;
   right: 24%;
+  will-change: transform;
 }
 
 .rounds__cancel--button:hover {

--- a/src/components/timer/TimerRoundsCounter.vue
+++ b/src/components/timer/TimerRoundsCounter.vue
@@ -55,6 +55,15 @@ onUnmounted(() => clearInterval(timeoutId));
 .rounds__cancel--button {
   display: flex;
   position: relative;
+  height: 0px;
+  top: -40px;
+  right: 24%;
+}
+
+.rounds__cancel--button:hover {
+  cursor: pointer;
+  transform: scale(1.05);
+  transition-duration: 100ms;
 }
 .rounds__paragraph:hover {
   cursor: pointer;

--- a/src/components/timer/TimerSettingsModal.vue
+++ b/src/components/timer/TimerSettingsModal.vue
@@ -93,21 +93,29 @@ onUnmounted(() => {
     <TimerSettingsModalFieldsetTimer v-model:timer-format="localTimerSettings.timerFormat" />
     <BaseInput
       v-model="localTimerSettings.focusDuration"
+      min="1"
+      max="99999"
       type="number" :label="`Focus duration (${timerFormatString})`"
     />
     <BaseInput
       v-model="localTimerSettings.shortBreakDuration"
       type="number"
+      min="1"
+      max="99999"
       :label="`Short break duration (${timerFormatString})`"
     />
     <BaseInput
       v-model="localTimerSettings.longBreakDuration"
       type="number"
+      min="1"
+      max="99999"
       :label="`Long break duration (${timerFormatString})`"
     />
     <BaseInput
       v-model="localTimerSettings.rounds"
       type="number"
+      min="1"
+      max="9999"
       label="Rounds"
     />
     <button class="submit" type="submit">

--- a/src/components/timer/TimerSettingsModal.vue
+++ b/src/components/timer/TimerSettingsModal.vue
@@ -3,6 +3,7 @@ import type { TimerSettingsModal } from '@/types/interfaces/TimerSettingsModal';
 import TimerSettingsModalFieldsetSound from '@/components/fieldsets/TimerSettingsModalFieldsetSound.vue';
 import TimerSettingsModalFieldsetTimer from '@/components/fieldsets/TimerSettingsModalFieldsetTimer.vue';
 import BaseInput from '@/components/inputs/BaseInput.vue';
+import { INPUT_LIMITS } from '@/types/enums/InputLimits';
 import { toMinutesFixed } from '@/utils/toMinutesFixed';
 import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
 
@@ -93,29 +94,29 @@ onUnmounted(() => {
     <TimerSettingsModalFieldsetTimer v-model:timer-format="localTimerSettings.timerFormat" />
     <BaseInput
       v-model="localTimerSettings.focusDuration"
-      min="1"
-      max="99999"
+      :min="INPUT_LIMITS.MIN_TIME"
+      :max="INPUT_LIMITS.MAX_TIME"
       type="number" :label="`Focus duration (${timerFormatString})`"
     />
     <BaseInput
       v-model="localTimerSettings.shortBreakDuration"
       type="number"
-      min="1"
-      max="99999"
+      :min="INPUT_LIMITS.MIN_TIME"
+      :max="INPUT_LIMITS.MAX_TIME"
       :label="`Short break duration (${timerFormatString})`"
     />
     <BaseInput
       v-model="localTimerSettings.longBreakDuration"
       type="number"
-      min="1"
-      max="99999"
+      :min="INPUT_LIMITS.MIN_TIME"
+      :max="INPUT_LIMITS.MAX_TIME"
       :label="`Long break duration (${timerFormatString})`"
     />
     <BaseInput
       v-model="localTimerSettings.rounds"
       type="number"
-      min="1"
-      max="9999"
+      :min="INPUT_LIMITS.MIN_ROUNDS"
+      :max="INPUT_LIMITS.MAX_ROUNDS"
       label="Rounds"
     />
     <button class="submit" type="submit">

--- a/src/components/timer/TimerSettingsModal.vue
+++ b/src/components/timer/TimerSettingsModal.vue
@@ -118,7 +118,7 @@ onUnmounted(() => {
 
 <style scoped>
 .modal {
-  padding: 15px;
+  padding: 16px;
   position: fixed;
   top: 10%;
   left: 42%;
@@ -132,7 +132,7 @@ onUnmounted(() => {
   background-color: black;
   color: #fff;
   height: 30px;
-  margin-top: 10px;
+  margin-top: 12px;
 }
 
 .submit:hover {

--- a/src/types/enums/InputLimits.ts
+++ b/src/types/enums/InputLimits.ts
@@ -1,0 +1,6 @@
+export enum INPUT_LIMITS {
+  MIN_TIME = `1`,
+  MAX_TIME = `99999`,
+  MIN_ROUNDS = `0`,
+  MAX_ROUNDS = `999`,
+}


### PR DESCRIPTION
- Выделил RadioInput из BaseInput в отдельный компонент
- Удалил все классы из svg иконок, вынес в родителей
- Чуть поправил margin/padding - чтобы были кратны 4px
- props.foo => foo в BaseInput и RadioInput

PS:
- Добавил классы в scoped style где их не было
- Добавил will-change к анимациям